### PR TITLE
tndus\add;.gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 /.metadata/
+/build/
+.env
+node_modules/
+vendor/
+.DS_Store
+.vscode/


### PR DESCRIPTION
주요 제외 이유

- 빌드 결과물 (build/): 소스코드만 있으면 언제든지 다시 만들 수 있는 파일들입니다. 용량이 크고 불필요해서 제외합니다.

- 민감한 정보 (.env): API 키, 비밀번호 등 보안상 중요한 개인 정보가 담겨 있어 외부에 노출되면 안 됩니다.

- 외부 라이브러리 (node_modules/, vendor/): 소스코드만으로 재설치가 가능하며, 용량이 매우 커서 제외합니다.

- 개인 설정/시스템 파일 (.DS_Store, .vscode/ 등): 운영체제나 개인의 개발 환경에 따라 생성되는 파일로, 팀원 간 충돌을 방지하기 위해 제외합니다.